### PR TITLE
test: Test AppHeaderBar

### DIFF
--- a/src/components/AppHeaderBar/AppHeaderBar.test.tsx
+++ b/src/components/AppHeaderBar/AppHeaderBar.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { DrawerContext } from "../../contexts/DrawerProvider";
+import { AppHeaderBar } from "./AppHeaderBar";
+
+jest.mock("../../config/featureToggle", () => ({
+  canShowSideMenuDrawer: () => true,
+}));
+
+describe("AppHeadBar", () => {
+  it("should render header text and logo", () => {
+    render(
+      <DrawerContext.Provider
+        value={{
+          showSideMenu: false,
+          setSideMenu: () => {},
+          showRouteSearchDrawer: false,
+          setRouteSearchDrawer: () => {},
+        }}
+      >
+        <AppHeaderBar />
+      </DrawerContext.Provider>
+    );
+
+    expect(screen.getByText(/MetroFare/)).toBeInTheDocument();
+    expect(screen.getByAltText(/Metro Fare logo/)).toBeInTheDocument();
+  });
+
+  it("should render menu button", () => {
+    render(
+      <DrawerContext.Provider
+        value={{
+          showSideMenu: false,
+          setSideMenu: () => {},
+          showRouteSearchDrawer: false,
+          setRouteSearchDrawer: () => {},
+        }}
+      >
+        <AppHeaderBar />
+      </DrawerContext.Provider>
+    );
+
+    expect(screen.getByRole("button", { name: "menu" }));
+  });
+});

--- a/src/components/AppHeaderBar/AppHeaderBar.tsx
+++ b/src/components/AppHeaderBar/AppHeaderBar.tsx
@@ -27,8 +27,13 @@ export const AppHeaderBar = () => {
             MetroFare
           </Typography>
           {canShowSideMenuDrawer() && (
-            <IconButton edge="start" color="inherit" aria-label="menu">
-              <MenuIcon onClick={() => setSideMenu(true)} />
+            <IconButton
+              edge="start"
+              color="inherit"
+              aria-label="menu"
+              onClick={() => setSideMenu(true)}
+            >
+              <MenuIcon />
             </IconButton>
           )}
         </Grid>


### PR DESCRIPTION
- Add test to AppHeadBar component
- Throw an error when `useDrawerContext` is used without `DrawerContext`

https://github.com/hspotlight/metro-fare/issues/43